### PR TITLE
Adding data-slate properties

### DIFF
--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-react",
   "description": "A set of React components for building completely customizable rich-text editors.",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "lib/slate-react.js",

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -450,6 +450,7 @@ class Content extends React.Component {
       <Container
         {...handlers}
         data-slate-editor
+        data-slate-node="value"
         ref={this.ref}
         data-key={document.key}
         contentEditable={readOnly ? null : true}
@@ -460,10 +461,6 @@ class Content extends React.Component {
         style={style}
         role={readOnly ? null : role || 'textbox'}
         tabIndex={tabIndex}
-        // COMPAT: The Grammarly Chrome extension works by changing the DOM out
-        // from under `contenteditable` elements, which leads to weird behaviors
-        // so we have to disable it like this. (2017/04/24)
-        data-gramm={false}
       >
         {children}
       </Container>

--- a/packages/slate-react/src/components/text.js
+++ b/packages/slate-react/src/components/text.js
@@ -139,7 +139,7 @@ class Text extends React.Component {
     })
 
     return (
-      <span data-key={key} style={style}>
+      <span data-slate-node="text" data-key={key} style={style}>
         {children}
       </span>
     )


### PR DESCRIPTION
We need to add a few dom attributes that are present in the new version of slate, so Grammarly can properly set the selection in the appropriate text.